### PR TITLE
Remove trailing comma in function call

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ for (const filename of ls('examples/*.html')) {
       chunksSortMode: 'manual',
       filename: name + '.html',
       chunks: ['common', name],
-    }),
+    })
   );
 }
 plugins.push(new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
Trailing commas in function calls are ES8 and don't work on my node v6.11.0.