### PR TITLE
Set loadTilesWhileInteracting to true

### DIFF
--- a/examples/ol-sbm-osm.js
+++ b/examples/ol-sbm-osm.js
@@ -56,6 +56,7 @@ const map = new Map({
       })
     })
   ],
+  loadTilesWhileInteracting: true,
   target: 'map',
   view: new  View({
     center: fromLonLat([7.75, 46.7]),


### PR DESCRIPTION
It has the side effect of not loading and parsing all the tile as once (on mouse up)